### PR TITLE
Pass remaining props through to TouchableWithoutFeedback

### DIFF
--- a/libs/icon/icon.js
+++ b/libs/icon/icon.js
@@ -33,7 +33,7 @@ class Icon extends Component {
   }
 
   render() {
-    const { label, type, from, size, iconStyle, onActiveColor, onInactiveColor } = this.props;
+    const { label, type, from, size, iconStyle, onActiveColor, onInactiveColor, ...rest } = this.props;
     const { selected } = this.state;
 
     const color = selected? onActiveColor : onInactiveColor
@@ -52,7 +52,7 @@ class Icon extends Component {
     }
 
     return (
-      <TouchableWithoutFeedback style={{ flex: 1 }} onPress={this.onPress.bind(this)}>
+      <TouchableWithoutFeedback {...rest} style={{ flex: 1 }} onPress={this.onPress.bind(this)}>
         <View style={styles.icon}>
           {icon}
           <View style={{ paddingTop: 5 }}>

--- a/libs/icon/icon_with_bar.js
+++ b/libs/icon/icon_with_bar.js
@@ -48,7 +48,8 @@ class IconWithBar extends Component {
       onActiveColor,
       onInactiveColor,
       onActiveColorBar,
-      onInactiveColorBar
+      onInactiveColorBar,
+      ...rest
     } = this.props;
     const { selected } = this.state;
 
@@ -71,7 +72,7 @@ class IconWithBar extends Component {
     }
 
     return (
-      <TouchableWithoutFeedback style={{ flex: 1 }} onPress={this.onPress.bind(this)}>
+      <TouchableWithoutFeedback {...rest} style={{ flex: 1 }} onPress={this.onPress.bind(this)}>
         <View style={[styles.icon, { borderTopWidth: borderWidth, borderTopColor: barColor, paddingTop: padding }]}>
           {icon}
           <View style={{ paddingTop: 5 }}>


### PR DESCRIPTION
I came across a problem while testing my application with Appium, which relies on the property `accesibilityLabel` to be set on `<TouchableWithoutFeedback />` on order to be able to find that element to "click". This PR passes all props not used by `<Icon />` and `<IconWithBar />` down to `<TouchableWithoutFeedback />` so it can be configured.
