### PR TITLE
Update width on orientation change, and pass onLayout from parent

### DIFF
--- a/example/WithIcons/app.js
+++ b/example/WithIcons/app.js
@@ -10,7 +10,9 @@ const glypy = glypyMapMaker({
 });
 
 export default class App extends Component {
-  onLayout = event => { console.log ("layout changed: " + event.nativeEvent.layout.width + "x" + event.nativeEvent.layout.height ) } 
+  onLayout = event => { 
+    console.log ("layout changed: " + event.nativeEvent.layout.width + "x" + event.nativeEvent.layout.height ); 
+  } 
 
   constructor(props, context) {
     super(props, context);

--- a/example/WithIcons/app.js
+++ b/example/WithIcons/app.js
@@ -10,7 +10,7 @@ const glypy = glypyMapMaker({
 });
 
 export default class App extends Component {
-  onLayout = event => { console.log ("layout changed: " + event.nativeEvent.layout) } 
+  onLayout = event => { console.log ("layout changed: " + event.nativeEvent.layout.width + "x" + event.nativeEvent.layout.height ) } 
 
   constructor(props, context) {
     super(props, context);

--- a/example/WithIcons/app.js
+++ b/example/WithIcons/app.js
@@ -10,6 +10,8 @@ const glypy = glypyMapMaker({
 });
 
 export default class App extends Component {
+  onLayout = event => { console.log ("layout changed: " + event.nativeEvent.layout) } 
+
   constructor(props, context) {
     super(props, context);
     this.toggle = false;
@@ -48,7 +50,7 @@ export default class App extends Component {
 
   render() {
     return (
-      <Tabbar ref="myTabbar" barColor={'gray'}>
+      <Tabbar ref="myTabbar" barColor={'gray'} onLayout={this.onLayout}>
         <Tab name="home">
           <IconWithBar label="Home" type={glypy.Home} from={'icomoon'}/>
           <RawContent>

--- a/libs/bar/normal.js
+++ b/libs/bar/normal.js
@@ -29,7 +29,7 @@ export default class Normalbar extends Component {
 
   render() {
     const { children, size, barColor } = this.props;
-    const { width } = window;
+    const width = this.props.width || window.width; 
 
     return (
       <Dynamicbar

--- a/libs/tabbar.js
+++ b/libs/tabbar.js
@@ -7,13 +7,20 @@ const REF_BAR = 'REF_BAR';
 
 //Tabbar
 export default class Tabbar extends Component {
+  onLayout = event => { 
+    const { width } = event.nativeEvent.layout;
+    this.setState({ width: width });
+    console.log ("width: " + width);
+  } 
+
   constructor(props, context) {
     super(props, context);
     this.prevContentRef = null;
     this.prevtabRef = null;
     this.state = {
       tabs: buildTabGraph(props.children),
-      activeTab: ''
+      activeTab: '',
+      width: null
     };
   }
 
@@ -98,11 +105,12 @@ export default class Tabbar extends Component {
   render() {
     const { BarComponent, barSize, barColor, onLayout } = this.props;
     return (
-      <View style={{ flex: 1 }} onLayout={onLayout}>
+      <View style={{ flex: 1 }} onLayout={this.onLayout}>
         {this.renderContents()}
         <BarComponent
           barColor={barColor}
           ref={REF_BAR}
+          width={this.state.width}
           size={barSize}>
           {this.renderIcons()}
         </BarComponent>

--- a/libs/tabbar.js
+++ b/libs/tabbar.js
@@ -93,7 +93,6 @@ export default class Tabbar extends Component {
       initialTab = this.state.tabs[0].name;
     }
     this.gotoTab(initialTab);
-    console.log ("TabBar mounted")
   }
 
   render() {

--- a/libs/tabbar.js
+++ b/libs/tabbar.js
@@ -7,10 +7,10 @@ const REF_BAR = 'REF_BAR';
 
 //Tabbar
 export default class Tabbar extends Component {
-  onLayout = event => { 
+  onLayoutInternal = (onLayout, event) => { 
     const { width } = event.nativeEvent.layout;
     this.setState({ width: width });
-    console.log ("width: " + width);
+    onLayout(event);
   } 
 
   constructor(props, context) {
@@ -105,7 +105,7 @@ export default class Tabbar extends Component {
   render() {
     const { BarComponent, barSize, barColor, onLayout } = this.props;
     return (
-      <View style={{ flex: 1 }} onLayout={this.onLayout}>
+      <View style={{ flex: 1 }} onLayout={this.onLayoutInternal.bind(this, onLayout)}>
         {this.renderContents()}
         <BarComponent
           barColor={barColor}

--- a/libs/tabbar.js
+++ b/libs/tabbar.js
@@ -7,11 +7,15 @@ const REF_BAR = 'REF_BAR';
 
 //Tabbar
 export default class Tabbar extends Component {
-  onLayoutInternal = (onLayout, event) => { 
+  onLayout = event => {
+    this.props.onLayout(event);
+    this.updateWidth(event); 
+  }
+
+  updateWidth = event => {
     const { width } = event.nativeEvent.layout;
     this.setState({ width: width });
-    onLayout(event);
-  } 
+  }
 
   constructor(props, context) {
     super(props, context);
@@ -105,7 +109,7 @@ export default class Tabbar extends Component {
   render() {
     const { BarComponent, barSize, barColor, onLayout } = this.props;
     return (
-      <View style={{ flex: 1 }} onLayout={this.onLayoutInternal.bind(this, onLayout)}>
+      <View style={{ flex: 1 }} onLayout={this.onLayout.bind(this)}>
         {this.renderContents()}
         <BarComponent
           barColor={barColor}

--- a/libs/tabbar.js
+++ b/libs/tabbar.js
@@ -93,12 +93,13 @@ export default class Tabbar extends Component {
       initialTab = this.state.tabs[0].name;
     }
     this.gotoTab(initialTab);
+    console.log ("TabBar mounted")
   }
 
   render() {
-    const { BarComponent, barSize, barColor } = this.props;
+    const { BarComponent, barSize, barColor, onLayout } = this.props;
     return (
-      <View style={{ flex: 1 }}>
+      <View style={{ flex: 1 }} onLayout={onLayout}>
         {this.renderContents()}
         <BarComponent
           barColor={barColor}

--- a/libs/util.js
+++ b/libs/util.js
@@ -3,22 +3,12 @@ import { Dimensions, Platform } from 'react-native';
 
 const windowInfo = Dimensions.get('window');
 
-// If we are in landscape switch width and height
-if (windowInfo.width > windowInfo.height) {
-  let width = windowInfo.height;
-  let height = windowInfo.width;
-  windowInfo.width = width;
-  windowInfo.height = height;
-} 
-
-console.log ("utils")
-
 //TODO: this is the hack, it needs to be replaced with a proper way to return a
 //proper height value for android
 //this magic number represents the height of tool bar provided by android os.
 const androidMagicNumber = 24;
 const window = {
-  width: windowInfo.width ,
+  width: windowInfo.width,
   height: Platform.OS === 'ios'? windowInfo.height : windowInfo.height - androidMagicNumber
 };
 

--- a/libs/util.js
+++ b/libs/util.js
@@ -3,12 +3,22 @@ import { Dimensions, Platform } from 'react-native';
 
 const windowInfo = Dimensions.get('window');
 
+// If we are in landscape switch width and height
+if (windowInfo.width > windowInfo.height) {
+  let width = windowInfo.height;
+  let height = windowInfo.width;
+  windowInfo.width = width;
+  windowInfo.height = height;
+} 
+
+console.log ("utils")
+
 //TODO: this is the hack, it needs to be replaced with a proper way to return a
 //proper height value for android
 //this magic number represents the height of tool bar provided by android os.
 const androidMagicNumber = 24;
 const window = {
-  width: windowInfo.width,
+  width: windowInfo.width ,
   height: Platform.OS === 'ios'? windowInfo.height : windowInfo.height - androidMagicNumber
 };
 


### PR DESCRIPTION
This both addresses #21 and allows to pass `onLayout` prop to Tabbar e.g.

``` js
<Tabbar ref="myTabbar" barColor={'gray'} onLayout={event => { console.log ("layout changed")}}>
```

See updated example.

I added the ability to pass in the `onLayout` prop as Tabbar is a root component in my app and I need to respond to `onLayout` events.
