### PR TITLE
setState instead of assigning this.state directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,16 +87,16 @@ export default class Tabar extends Component {
   constructor(props, context) {
     super(props, context)
     const { height, offset, step, show } = props
-    this.state = this.makeState(height, offset, step, show)
+    this.makeState(height, offset, step, show)
     this.ignoreFirstLayoutCall = true
   }
 
   makeState(height, offset, step, show) {
     const top = this.calculateTop(height)
-    return {
+    this.setState({
       top: new Animated.Value(top),
       scroll: magicScroll(0, height, offset, step)
-    }
+    })
   }
 
   updateHeight = (scrollY) => {
@@ -179,7 +179,7 @@ export default class Tabar extends Component {
         this.props.offset !== nextProps.offset ||
         this.props.step !== nextProps.step ||
         this.props.show !== nextProps.show) {
-        this.state = this.makeState(
+        this.makeState(
           nextProps.height,
           nextProps.offset,
           nextProps.step,


### PR DESCRIPTION
- To remove warning message for setting state in `componentWillReceiveProps()` method

![screen shot 2017-04-26 at 12 00 40 pm](https://cloud.githubusercontent.com/assets/2831540/25416290/028661d0-2a78-11e7-965f-8c476a917004.png)